### PR TITLE
fix: merge auto-detected tokens into user config

### DIFF
--- a/apps/cli/src/config/loader.ts
+++ b/apps/cli/src/config/loader.ts
@@ -12,7 +12,7 @@ import { buildAutoConfig } from './auto-detect.js';
  * These are the component scanning sources (not tokens/figma/storybook).
  */
 const AUTO_DETECTABLE_SOURCES: (keyof SourcesConfig)[] = [
-  'react', 'vue', 'svelte', 'angular', 'webcomponent', 'templates', 'tailwind'
+  'react', 'vue', 'svelte', 'angular', 'webcomponent', 'templates', 'tailwind', 'tokens'
 ];
 
 /**


### PR DESCRIPTION
## Summary
- Add `'tokens'` to `AUTO_DETECTABLE_SOURCES` in `loader.ts` so auto-detected token files are merged into user configs that don't explicitly define a tokens section
- Fixes `show tokens` returning empty `[]` and health score `tokenHealth: 0` for projects with Tailwind v4 `@theme` blocks (or any CSS `:root` tokens) when the user has a config file without a tokens section

## Root cause
`findTokenFiles()` correctly discovers CSS files with `@theme` blocks and `:root` custom properties. `buildAutoConfig()` correctly creates a `sources.tokens` config from those files. But `mergeAutoDetectedSources()` only merges sources listed in `AUTO_DETECTABLE_SOURCES` — and `tokens` wasn't in that list.

When a user has a `buoy.config.mjs` (like buoy-site), the auto-detected tokens were silently dropped, causing the orchestrator to skip token scanning entirely.

## Test plan
- [x] All 63 existing config/scan tests pass
- [ ] Verify `buoy show tokens` returns tokens for a project with `@theme` blocks and a user config file
- [ ] Verify `buoy show health` reports correct tokenHealth score (should be 20/20 when tokens are found)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The CLI configuration system now includes 'tokens' as an auto-detectable source. This enhancement expands the set of framework sources that can be automatically detected and merged into your user configurations. The merge behavior remains consistent while extending coverage to more configuration sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->