### PR TITLE
Phase A: DESIGN.md (Google) integration in the CLI

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -44,6 +44,7 @@
     "@anthropic-ai/sdk": "^0.71.2",
     "@buoy-design/core": "workspace:*",
     "@buoy-design/scanners": "workspace:*",
+    "@google/design.md": "0.1.1",
     "@inquirer/prompts": "^8.1.0",
     "@octokit/rest": "^21.0.0",
     "chalk": "^5.3.0",

--- a/apps/cli/src/commands/designmd/__tests__/diff.test.ts
+++ b/apps/cli/src/commands/designmd/__tests__/diff.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { diffDesignMd } from "../diff.js";
+
+vi.mock("node:fs", async (orig) => ({
+  ...(await orig<typeof import("node:fs")>()),
+  readFileSync: vi.fn(),
+}));
+import { readFileSync } from "node:fs";
+
+describe("diffDesignMd", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns exit 0 when 'after' has no new errors/warnings vs 'before'", () => {
+    const clean = `---\nname: A\ncolors:\n  primary: "#000000"\n---\n`;
+    vi.mocked(readFileSync)
+      .mockReturnValueOnce(clean)
+      .mockReturnValueOnce(clean);
+    const r = diffDesignMd({ before: "a.md", after: "b.md" });
+    expect(r.exitCode).toBe(0);
+    expect(r.json.regression).toBe(false);
+  });
+
+  it("returns exit 1 when 'after' introduces a regression", () => {
+    const clean = `---\nname: A\ncolors:\n  primary: "#000000"\n---\n`;
+    // Use 'not-a-hex' (real upstream-error trigger in v0.1.1)
+    const broken = `---\nname: A\ncolors:\n  primary: not-a-hex\n---\n`;
+    vi.mocked(readFileSync)
+      .mockReturnValueOnce(clean)
+      .mockReturnValueOnce(broken);
+    const r = diffDesignMd({ before: "a.md", after: "b.md" });
+    expect(r.exitCode).toBe(1);
+    expect(r.json.regression).toBe(true);
+  });
+
+  it("reports added/removed/modified tokens by category", () => {
+    const before = `---\nname: A\ncolors:\n  primary: "#000000"\n  secondary: "#111111"\nspacing:\n  md: 16px\n---\n`;
+    const after = `---\nname: A\ncolors:\n  primary: "#222222"\n  tertiary: "#333333"\nspacing:\n  md: 16px\n---\n`;
+    vi.mocked(readFileSync)
+      .mockReturnValueOnce(before)
+      .mockReturnValueOnce(after);
+    const r = diffDesignMd({ before: "a.md", after: "b.md" });
+    expect(r.json.tokens.colors).toEqual({
+      added: ["tertiary"],
+      removed: ["secondary"],
+      modified: ["primary"],
+    });
+    expect(r.json.tokens.spacing).toEqual({
+      added: [],
+      removed: [],
+      modified: [],
+    });
+  });
+});

--- a/apps/cli/src/commands/designmd/__tests__/diff.test.ts
+++ b/apps/cli/src/commands/designmd/__tests__/diff.test.ts
@@ -22,7 +22,9 @@ describe("diffDesignMd", () => {
 
   it("returns exit 1 when 'after' introduces a regression", () => {
     const clean = `---\nname: A\ncolors:\n  primary: "#000000"\n---\n`;
-    // Use 'not-a-hex' (real upstream-error trigger in v0.1.1)
+    // invalid hex triggers core validation in @google/design.md@0.1.1.
+    // Token-reference rules ({colors.foo}) are NOT enforced at this version,
+    // so we use an invalid color value to drive the error path.
     const broken = `---\nname: A\ncolors:\n  primary: not-a-hex\n---\n`;
     vi.mocked(readFileSync)
       .mockReturnValueOnce(clean)
@@ -39,11 +41,9 @@ describe("diffDesignMd", () => {
       .mockReturnValueOnce(before)
       .mockReturnValueOnce(after);
     const r = diffDesignMd({ before: "a.md", after: "b.md" });
-    expect(r.json.tokens.colors).toEqual({
-      added: ["tertiary"],
-      removed: ["secondary"],
-      modified: ["primary"],
-    });
+    expect(r.json.tokens.colors.added).toEqual(["tertiary"]);
+    expect(r.json.tokens.colors.removed).toEqual(["secondary"]);
+    expect(r.json.tokens.colors.modified).toEqual(["primary"]);
     expect(r.json.tokens.spacing).toEqual({
       added: [],
       removed: [],

--- a/apps/cli/src/commands/designmd/__tests__/export.test.ts
+++ b/apps/cli/src/commands/designmd/__tests__/export.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { exportDesignMd } from "../export.js";
+
+vi.mock("node:fs", async (orig) => ({
+  ...(await orig<typeof import("node:fs")>()),
+  readFileSync: vi.fn(),
+}));
+import { readFileSync } from "node:fs";
+
+const FIXTURE = `---
+name: Test
+colors:
+  primary: "#1A1C1E"
+spacing:
+  md: 16px
+rounded:
+  md: 8px
+---
+`;
+
+describe("exportDesignMd", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("exports tailwind theme JSON", () => {
+    vi.mocked(readFileSync).mockReturnValue(FIXTURE);
+    const r = exportDesignMd({ file: "DESIGN.md", format: "tailwind" });
+    expect(r.exitCode).toBe(0);
+    const out = JSON.parse(r.stdout);
+    // upstream lowercases hex
+    expect(out.theme.colors.primary).toBe("#1a1c1e");
+    expect(out.theme.spacing.md).toBe("16px");
+    expect(out.theme.borderRadius.md).toBe("8px");
+  });
+
+  it("exports DTCG tokens JSON", () => {
+    vi.mocked(readFileSync).mockReturnValue(FIXTURE);
+    const r = exportDesignMd({ file: "DESIGN.md", format: "dtcg" });
+    expect(r.exitCode).toBe(0);
+    const out = JSON.parse(r.stdout);
+    expect(out.color.primary.$value).toBe("#1a1c1e");
+    expect(out.color.primary.$type).toBe("color");
+    expect(out.dimension.md.$value).toBe("16px");
+    expect(out.dimension.md.$type).toBe("dimension");
+  });
+
+  it("returns exit 1 and the lint result when input has errors", () => {
+    vi.mocked(readFileSync).mockReturnValue(
+      `---\ncolors:\n  primary: not-a-hex\n---\n`,
+    );
+    const r = exportDesignMd({ file: "DESIGN.md", format: "tailwind" });
+    expect(r.exitCode).toBe(1);
+    // stdout should contain the lint result as JSON, not a tailwind theme
+    const parsed = JSON.parse(r.stdout);
+    expect(parsed).toHaveProperty("summary");
+    expect(parsed.summary.errors).toBeGreaterThan(0);
+  });
+});

--- a/apps/cli/src/commands/designmd/__tests__/fixture.md
+++ b/apps/cli/src/commands/designmd/__tests__/fixture.md
@@ -1,0 +1,9 @@
+---
+name: Smoke Test
+colors:
+  primary: "#000000"
+---
+
+## Overview
+
+Smoke fixture.

--- a/apps/cli/src/commands/designmd/__tests__/init.test.ts
+++ b/apps/cli/src/commands/designmd/__tests__/init.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { generateDesignMd } from "../init.js";
+import { parseDesignMd } from "@buoy-design/core";
+import type { DesignToken } from "@buoy-design/core";
+
+const fakeTokens: DesignToken[] = [
+  {
+    id: "color.primary",
+    name: "primary",
+    category: "color",
+    value: { type: "string", raw: "#1A1C1E" } as any,
+  } as any,
+  {
+    id: "spacing.md",
+    name: "md",
+    category: "spacing",
+    value: { type: "string", raw: "16px" } as any,
+  } as any,
+];
+
+describe("generateDesignMd", () => {
+  it("emits a DESIGN.md that parses cleanly", () => {
+    const md = generateDesignMd({ name: "MyApp", tokens: fakeTokens });
+    expect(md).toContain("name: MyApp");
+    // Hex preserved verbatim in the source; upstream lowercases on parse,
+    // so we assert the source string and the parse round-trip separately.
+    expect(md).toMatch(/primary:\s*"#1A1C1E"/);
+    const parsed = parseDesignMd(md);
+    expect(parsed.summary.errors).toBe(0);
+    expect(parsed.designSystem.name).toBe("MyApp");
+  });
+
+  it("emits a placeholder Overview prose block", () => {
+    const md = generateDesignMd({ name: "X", tokens: [] });
+    expect(md).toMatch(/## Overview/);
+  });
+
+  it("emits a parseable file even with zero tokens", () => {
+    const md = generateDesignMd({ name: "Empty", tokens: [] });
+    const parsed = parseDesignMd(md);
+    expect(parsed.summary.errors).toBe(0);
+  });
+});

--- a/apps/cli/src/commands/designmd/__tests__/init.test.ts
+++ b/apps/cli/src/commands/designmd/__tests__/init.test.ts
@@ -1,21 +1,33 @@
 import { describe, it, expect } from "vitest";
-import { generateDesignMd } from "../init.js";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { discoverAndGenerate, generateDesignMd } from "../init.js";
 import { parseDesignMd } from "@buoy-design/core";
 import type { DesignToken } from "@buoy-design/core";
 
 const fakeTokens: DesignToken[] = [
   {
-    id: "color.primary",
+    id: "css:tokens.css:primary",
     name: "primary",
     category: "color",
-    value: { type: "string", raw: "#1A1C1E" } as any,
-  } as any,
+    value: { type: "color", hex: "#1A1C1E" },
+    source: { type: "css", path: "tokens.css" },
+    aliases: [],
+    usedBy: [],
+    metadata: {},
+    scannedAt: new Date(),
+  },
   {
-    id: "spacing.md",
+    id: "css:tokens.css:md",
     name: "md",
     category: "spacing",
-    value: { type: "string", raw: "16px" } as any,
-  } as any,
+    value: { type: "spacing", value: 16, unit: "px" },
+    source: { type: "css", path: "tokens.css" },
+    aliases: [],
+    usedBy: [],
+    metadata: {},
+    scannedAt: new Date(),
+  },
 ];
 
 describe("generateDesignMd", () => {
@@ -25,6 +37,8 @@ describe("generateDesignMd", () => {
     // Hex preserved verbatim in the source; upstream lowercases on parse,
     // so we assert the source string and the parse round-trip separately.
     expect(md).toMatch(/primary:\s*"#1A1C1E"/);
+    // Spacing rendered as `${value}${unit}` from the discriminated union.
+    expect(md).toMatch(/md:\s*16px/);
     const parsed = parseDesignMd(md);
     expect(parsed.summary.errors).toBe(0);
     expect(parsed.designSystem.name).toBe("MyApp");
@@ -40,4 +54,34 @@ describe("generateDesignMd", () => {
     const parsed = parseDesignMd(md);
     expect(parsed.summary.errors).toBe(0);
   });
+
+  // The test-fixture directory is gitignored and lives one level above the
+  // worktree root (in the main checkout). Skip the integration test gracefully
+  // when it isn't present so the suite stays portable across worktrees / CI.
+  const fixtureRoot = resolve(
+    __dirname,
+    "../../../../../../../../test-fixture",
+  );
+  const fixtureExists = existsSync(fixtureRoot);
+  const integrationIt = fixtureExists ? it : it.skip;
+
+  integrationIt(
+    "integration: discovers tokens from test-fixture and emits a parseable DESIGN.md",
+    async () => {
+      const md = await discoverAndGenerate({
+        cwd: fixtureRoot,
+        name: "TestFixture",
+      });
+      const parsed = parseDesignMd(md);
+      expect(parsed.summary.errors).toBe(0);
+      expect(parsed.designSystem.name).toBe("TestFixture");
+      // Don't assert specific tokens — the fixture may evolve. Just confirm
+      // we found at least some.
+      const tokenCount =
+        Object.keys(parsed.designSystem.colors ?? {}).length +
+        Object.keys(parsed.designSystem.spacing ?? {}).length +
+        Object.keys(parsed.designSystem.rounded ?? {}).length;
+      expect(tokenCount).toBeGreaterThan(0);
+    },
+  );
 });

--- a/apps/cli/src/commands/designmd/__tests__/lint.test.ts
+++ b/apps/cli/src/commands/designmd/__tests__/lint.test.ts
@@ -21,6 +21,9 @@ describe("lintDesignMd CLI logic", () => {
   });
 
   it("returns exit 1 when errors are found", () => {
+    // invalid hex triggers core validation in @google/design.md@0.1.1.
+    // Token-reference rules ({colors.foo}) are NOT enforced at this version,
+    // so we use an invalid color value to drive the error path.
     vi.mocked(readFileSync).mockReturnValue(
       `---\ncolors:\n  primary: not-a-hex\n---\n`
     );

--- a/apps/cli/src/commands/designmd/__tests__/lint.test.ts
+++ b/apps/cli/src/commands/designmd/__tests__/lint.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { lintDesignMd, type LintCliResult } from "../lint.js";
+
+vi.mock("node:fs", async (orig) => ({
+  ...(await orig<typeof import("node:fs")>()),
+  readFileSync: vi.fn(),
+}));
+
+import { readFileSync } from "node:fs";
+
+describe("lintDesignMd CLI logic", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns exit 0 and JSON for a clean file", () => {
+    vi.mocked(readFileSync).mockReturnValue(
+      `---\nname: Test\ncolors:\n  primary: "#000000"\n---\n`
+    );
+    const result: LintCliResult = lintDesignMd({ file: "DESIGN.md" });
+    expect(result.exitCode).toBe(0);
+    expect(result.json.summary.errors).toBe(0);
+  });
+
+  it("returns exit 1 when errors are found", () => {
+    vi.mocked(readFileSync).mockReturnValue(
+      `---\ncolors:\n  primary: not-a-hex\n---\n`
+    );
+    const result = lintDesignMd({ file: "DESIGN.md" });
+    expect(result.exitCode).toBe(1);
+    expect(result.json.summary.errors).toBeGreaterThan(0);
+  });
+});

--- a/apps/cli/src/commands/designmd/diff.ts
+++ b/apps/cli/src/commands/designmd/diff.ts
@@ -1,0 +1,74 @@
+import { readFileSync } from "node:fs";
+import { parseDesignMd } from "@buoy-design/core";
+
+export interface DiffCliOptions {
+  before: string;
+  after: string;
+}
+
+export interface TokenDiff {
+  added: string[];
+  removed: string[];
+  modified: string[];
+}
+
+export interface DiffCliResult {
+  exitCode: 0 | 1;
+  json: {
+    tokens: {
+      colors: TokenDiff;
+      typography: TokenDiff;
+      spacing: TokenDiff;
+      rounded: TokenDiff;
+      components: TokenDiff;
+    };
+    regression: boolean;
+    summary: {
+      before: { errors: number; warnings: number };
+      after: { errors: number; warnings: number };
+    };
+  };
+}
+
+function diffSet<T>(
+  before: Record<string, T> | undefined,
+  after: Record<string, T> | undefined,
+): TokenDiff {
+  const a = before ?? {};
+  const b = after ?? {};
+  const added = Object.keys(b).filter((k) => !(k in a));
+  const removed = Object.keys(a).filter((k) => !(k in b));
+  const modified = Object.keys(b).filter(
+    (k) => k in a && JSON.stringify(a[k]) !== JSON.stringify(b[k]),
+  );
+  return { added, removed, modified };
+}
+
+export function diffDesignMd(opts: DiffCliOptions): DiffCliResult {
+  const before = parseDesignMd(readFileSync(opts.before, "utf8"));
+  const after = parseDesignMd(readFileSync(opts.after, "utf8"));
+
+  const tokens = {
+    colors: diffSet(before.designSystem.colors, after.designSystem.colors),
+    typography: diffSet(before.designSystem.typography, after.designSystem.typography),
+    spacing: diffSet(before.designSystem.spacing, after.designSystem.spacing),
+    rounded: diffSet(before.designSystem.rounded, after.designSystem.rounded),
+    components: diffSet(before.designSystem.components, after.designSystem.components),
+  };
+
+  const regression =
+    after.summary.errors > before.summary.errors ||
+    after.summary.warnings > before.summary.warnings;
+
+  return {
+    exitCode: regression ? 1 : 0,
+    json: {
+      tokens,
+      regression,
+      summary: {
+        before: { errors: before.summary.errors, warnings: before.summary.warnings },
+        after: { errors: after.summary.errors, warnings: after.summary.warnings },
+      },
+    },
+  };
+}

--- a/apps/cli/src/commands/designmd/export.ts
+++ b/apps/cli/src/commands/designmd/export.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from "node:fs";
+import { parseDesignMd, type DesignMdSystem } from "@buoy-design/core";
+
+export type ExportFormat = "tailwind" | "dtcg";
+
+export interface ExportCliOptions {
+  file: string;
+  format: ExportFormat;
+}
+
+export interface ExportCliResult {
+  exitCode: 0 | 1;
+  stdout: string;
+}
+
+function toTailwind(ds: DesignMdSystem): unknown {
+  return {
+    theme: {
+      colors: ds.colors ?? {},
+      spacing: ds.spacing ?? {},
+      borderRadius: ds.rounded ?? {},
+      fontFamily: Object.fromEntries(
+        Object.entries(ds.typography ?? {}).map(([k, v]) => [
+          k,
+          [(v as { fontFamily?: string }).fontFamily ?? "sans-serif"],
+        ]),
+      ),
+    },
+  };
+}
+
+function toDtcg(ds: DesignMdSystem): unknown {
+  const out: Record<string, Record<string, { $value: unknown; $type: string }>> = {};
+  if (ds.colors) {
+    out.color = Object.fromEntries(
+      Object.entries(ds.colors).map(([k, v]) => [k, { $value: v, $type: "color" }]),
+    );
+  }
+  if (ds.spacing) {
+    out.dimension = Object.fromEntries(
+      Object.entries(ds.spacing).map(([k, v]) => [k, { $value: v, $type: "dimension" }]),
+    );
+  }
+  return out;
+}
+
+export function exportDesignMd(opts: ExportCliOptions): ExportCliResult {
+  const source = readFileSync(opts.file, "utf8");
+  const result = parseDesignMd(source);
+  if (result.summary.errors > 0) {
+    return { exitCode: 1, stdout: JSON.stringify(result, null, 2) };
+  }
+  const out =
+    opts.format === "tailwind"
+      ? toTailwind(result.designSystem)
+      : toDtcg(result.designSystem);
+  return { exitCode: 0, stdout: JSON.stringify(out, null, 2) };
+}

--- a/apps/cli/src/commands/designmd/index.ts
+++ b/apps/cli/src/commands/designmd/index.ts
@@ -3,7 +3,7 @@ import { Command } from "commander";
 import { lintDesignMd } from "./lint.js";
 import { diffDesignMd } from "./diff.js";
 import { exportDesignMd } from "./export.js";
-import { generateDesignMd } from "./init.js";
+import { discoverAndGenerate } from "./init.js";
 
 export function createDesignMdCommand(): Command {
   const cmd = new Command("designmd")
@@ -47,9 +47,11 @@ export function createDesignMdCommand(): Command {
     .description("Generate a DESIGN.md from discovered tokens")
     .option("-o, --output <path>", "Write to file (default: stdout)")
     .option("--name <name>", "Design system name", "Untitled")
-    .action((opts: { output?: string; name: string }) => {
-      // Token discovery wired in Task 8 — emit empty skeleton for now.
-      const md = generateDesignMd({ name: opts.name, tokens: [] });
+    .action(async (opts: { output?: string; name: string }) => {
+      const md = await discoverAndGenerate({
+        cwd: process.cwd(),
+        name: opts.name,
+      });
       if (opts.output) writeFileSync(opts.output, md);
       else process.stdout.write(md);
     });

--- a/apps/cli/src/commands/designmd/index.ts
+++ b/apps/cli/src/commands/designmd/index.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import { lintDesignMd } from "./lint.js";
 import { diffDesignMd } from "./diff.js";
+import { exportDesignMd } from "./export.js";
 
 export function createDesignMdCommand(): Command {
   const cmd = new Command("designmd")
@@ -22,6 +23,20 @@ export function createDesignMdCommand(): Command {
     .action((before: string, after: string) => {
       const { exitCode, json } = diffDesignMd({ before, after });
       process.stdout.write(JSON.stringify(json, null, 2) + "\n");
+      process.exit(exitCode);
+    });
+
+  cmd
+    .command("export <file>")
+    .description("Export DESIGN.md tokens to tailwind or dtcg format")
+    .requiredOption("--format <format>", "tailwind | dtcg")
+    .action((file: string, opts: { format: string }) => {
+      if (opts.format !== "tailwind" && opts.format !== "dtcg") {
+        process.stderr.write(`Unknown format: ${opts.format}\n`);
+        process.exit(1);
+      }
+      const { exitCode, stdout } = exportDesignMd({ file, format: opts.format });
+      process.stdout.write(stdout + "\n");
       process.exit(exitCode);
     });
 

--- a/apps/cli/src/commands/designmd/index.ts
+++ b/apps/cli/src/commands/designmd/index.ts
@@ -1,0 +1,19 @@
+import { Command } from "commander";
+import { lintDesignMd } from "./lint.js";
+
+export function createDesignMdCommand(): Command {
+  const cmd = new Command("designmd")
+    .description("Author and validate DESIGN.md files")
+    .configureHelp({ sortSubcommands: false });
+
+  cmd
+    .command("lint <file>")
+    .description("Validate a DESIGN.md file (use '-' for stdin)")
+    .action((file: string) => {
+      const { exitCode, json } = lintDesignMd({ file });
+      process.stdout.write(JSON.stringify(json, null, 2) + "\n");
+      process.exit(exitCode);
+    });
+
+  return cmd;
+}

--- a/apps/cli/src/commands/designmd/index.ts
+++ b/apps/cli/src/commands/designmd/index.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import { lintDesignMd } from "./lint.js";
+import { diffDesignMd } from "./diff.js";
 
 export function createDesignMdCommand(): Command {
   const cmd = new Command("designmd")
@@ -11,6 +12,15 @@ export function createDesignMdCommand(): Command {
     .description("Validate a DESIGN.md file (use '-' for stdin)")
     .action((file: string) => {
       const { exitCode, json } = lintDesignMd({ file });
+      process.stdout.write(JSON.stringify(json, null, 2) + "\n");
+      process.exit(exitCode);
+    });
+
+  cmd
+    .command("diff <before> <after>")
+    .description("Compare two DESIGN.md files for token regressions")
+    .action((before: string, after: string) => {
+      const { exitCode, json } = diffDesignMd({ before, after });
       process.stdout.write(JSON.stringify(json, null, 2) + "\n");
       process.exit(exitCode);
     });

--- a/apps/cli/src/commands/designmd/index.ts
+++ b/apps/cli/src/commands/designmd/index.ts
@@ -1,7 +1,9 @@
+import { writeFileSync } from "node:fs";
 import { Command } from "commander";
 import { lintDesignMd } from "./lint.js";
 import { diffDesignMd } from "./diff.js";
 import { exportDesignMd } from "./export.js";
+import { generateDesignMd } from "./init.js";
 
 export function createDesignMdCommand(): Command {
   const cmd = new Command("designmd")
@@ -38,6 +40,18 @@ export function createDesignMdCommand(): Command {
       const { exitCode, stdout } = exportDesignMd({ file, format: opts.format });
       process.stdout.write(stdout + "\n");
       process.exit(exitCode);
+    });
+
+  cmd
+    .command("init")
+    .description("Generate a DESIGN.md from discovered tokens")
+    .option("-o, --output <path>", "Write to file (default: stdout)")
+    .option("--name <name>", "Design system name", "Untitled")
+    .action((opts: { output?: string; name: string }) => {
+      // Token discovery wired in Task 8 — emit empty skeleton for now.
+      const md = generateDesignMd({ name: opts.name, tokens: [] });
+      if (opts.output) writeFileSync(opts.output, md);
+      else process.stdout.write(md);
     });
 
   return cmd;

--- a/apps/cli/src/commands/designmd/init.ts
+++ b/apps/cli/src/commands/designmd/init.ts
@@ -1,4 +1,5 @@
 import { stringify as stringifyYaml } from "yaml";
+import { TokenScanner } from "@buoy-design/scanners";
 import type { DesignToken } from "@buoy-design/core";
 
 export interface GenerateOptions {
@@ -6,20 +7,73 @@ export interface GenerateOptions {
   tokens: DesignToken[];
 }
 
+type DesignMdEntry = {
+  kind: "color" | "spacing" | "rounded";
+  name: string;
+  value: string;
+};
+
+/**
+ * Map a DesignToken's discriminated `value` union to a DESIGN.md primitive
+ * entry, or return null when the token doesn't fit one of the v1 buckets
+ * (typography, shadow, sizing, motion, zIndex, other, plain border).
+ */
+function tokenToDesignMdEntry(token: DesignToken): DesignMdEntry | null {
+  const value = token.value;
+
+  switch (value.type) {
+    case "color":
+      if (token.category === "color") {
+        return { kind: "color", name: token.name, value: value.hex };
+      }
+      return null;
+
+    case "spacing":
+      if (token.category === "spacing") {
+        return {
+          kind: "spacing",
+          name: token.name,
+          value: `${value.value}${value.unit}`,
+        };
+      }
+      return null;
+
+    case "border":
+      // Border itself isn't a DESIGN.md primitive, but its radius is.
+      if (typeof value.radius === "number") {
+        return { kind: "rounded", name: token.name, value: `${value.radius}px` };
+      }
+      return null;
+
+    case "raw":
+      // For raw tokens we trust the category to route them.
+      if (token.category === "color") {
+        return { kind: "color", name: token.name, value: value.value };
+      }
+      if (token.category === "spacing") {
+        return { kind: "spacing", name: token.name, value: value.value };
+      }
+      return null;
+
+    case "typography":
+    case "shadow":
+    default:
+      return null;
+  }
+}
+
 export function generateDesignMd(opts: GenerateOptions): string {
   const colors: Record<string, string> = {};
   const spacing: Record<string, string> = {};
   const rounded: Record<string, string> = {};
 
-  for (const t of opts.tokens) {
-    const raw = String((t as { value?: { raw?: unknown } }).value?.raw ?? "");
-    if (raw === "") continue;
-    const category = t.category as string;
-    if (category === "color") colors[t.name] = raw;
-    else if (category === "spacing") spacing[t.name] = raw;
-    else if (category === "radius" || category === "rounded") {
-      rounded[t.name] = raw;
-    }
+  for (const token of opts.tokens) {
+    const entry = tokenToDesignMdEntry(token);
+    if (!entry) continue;
+
+    if (entry.kind === "color") colors[entry.name] = entry.value;
+    else if (entry.kind === "spacing") spacing[entry.name] = entry.value;
+    else if (entry.kind === "rounded") rounded[entry.name] = entry.value;
   }
 
   const frontMatter: Record<string, unknown> = {
@@ -32,4 +86,23 @@ export function generateDesignMd(opts: GenerateOptions): string {
 
   const yaml = stringifyYaml(frontMatter);
   return `---\n${yaml}---\n\n## Overview\n\n_Describe the design language here. Replace this with your team's voice and intent._\n`;
+}
+
+/**
+ * Run token discovery against a project root and produce a DESIGN.md string.
+ *
+ * Wires `buoy designmd init` to the real scanner pipeline used by `compare`,
+ * so the same CSS / SCSS / JSON sources feed both commands.
+ */
+export async function discoverAndGenerate(opts: {
+  cwd: string;
+  name: string;
+}): Promise<string> {
+  const scanner = new TokenScanner({
+    projectRoot: opts.cwd,
+    include: ["**/*.css", "**/*.scss", "**/*.json"],
+    exclude: ["**/node_modules/**", "**/dist/**", "**/build/**", "**/*.min.css"],
+  });
+  const scanResult = await scanner.scan();
+  return generateDesignMd({ name: opts.name, tokens: scanResult.items });
 }

--- a/apps/cli/src/commands/designmd/init.ts
+++ b/apps/cli/src/commands/designmd/init.ts
@@ -1,0 +1,35 @@
+import { stringify as stringifyYaml } from "yaml";
+import type { DesignToken } from "@buoy-design/core";
+
+export interface GenerateOptions {
+  name: string;
+  tokens: DesignToken[];
+}
+
+export function generateDesignMd(opts: GenerateOptions): string {
+  const colors: Record<string, string> = {};
+  const spacing: Record<string, string> = {};
+  const rounded: Record<string, string> = {};
+
+  for (const t of opts.tokens) {
+    const raw = String((t as { value?: { raw?: unknown } }).value?.raw ?? "");
+    if (raw === "") continue;
+    const category = t.category as string;
+    if (category === "color") colors[t.name] = raw;
+    else if (category === "spacing") spacing[t.name] = raw;
+    else if (category === "radius" || category === "rounded") {
+      rounded[t.name] = raw;
+    }
+  }
+
+  const frontMatter: Record<string, unknown> = {
+    version: "alpha",
+    name: opts.name,
+  };
+  if (Object.keys(colors).length > 0) frontMatter.colors = colors;
+  if (Object.keys(spacing).length > 0) frontMatter.spacing = spacing;
+  if (Object.keys(rounded).length > 0) frontMatter.rounded = rounded;
+
+  const yaml = stringifyYaml(frontMatter);
+  return `---\n${yaml}---\n\n## Overview\n\n_Describe the design language here. Replace this with your team's voice and intent._\n`;
+}

--- a/apps/cli/src/commands/designmd/lint.ts
+++ b/apps/cli/src/commands/designmd/lint.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from "node:fs";
+import { parseDesignMd, type DesignMdResult } from "@buoy-design/core";
+
+export interface LintCliOptions {
+  file: string;
+}
+
+export interface LintCliResult {
+  exitCode: 0 | 1;
+  json: DesignMdResult;
+}
+
+export function lintDesignMd(opts: LintCliOptions): LintCliResult {
+  const source =
+    opts.file === "-"
+      ? readFileSync(0, "utf8") // stdin
+      : readFileSync(opts.file, "utf8");
+  const result = parseDesignMd(source);
+  return {
+    exitCode: result.summary.errors > 0 ? 1 : 0,
+    json: result,
+  };
+}

--- a/apps/cli/src/commands/index.ts
+++ b/apps/cli/src/commands/index.ts
@@ -2,6 +2,7 @@ export { createShowCommand } from "./show.js";
 export { createDriftCommand } from "./drift.js";
 export { createDockCommand } from "./dock.js";
 export { createAhoyCommand } from "./ahoy.js";
+export { createDesignMdCommand } from "./designmd/index.js";
 
 // Re-exports for internal use (subcommands within groups)
 export { createCheckCommand } from "./check.js";

--- a/apps/cli/src/config/auto-detect.ts
+++ b/apps/cli/src/config/auto-detect.ts
@@ -422,6 +422,10 @@ export async function buildAutoConfig(projectRoot: string = process.cwd()): Prom
  */
 export async function findTokenFiles(projectRoot: string): Promise<string[]> {
   const patterns = [
+    // DESIGN.md (highest-priority token source when present)
+    'DESIGN.md',
+    '**/DESIGN.md',
+
     // CSS custom properties - explicit token files
     '**/tokens.css',
     '**/variables.css',

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -5,6 +5,7 @@ import {
   createDriftCommand,
   createDockCommand,
   createAhoyCommand,
+  createDesignMdCommand,
 } from "./commands/index.js";
 
 export function createCli(): Command {
@@ -26,6 +27,7 @@ Command Groups:
   Drift Actions      drift (scan, check, fix, ignore)
   Setup              dock (config, skills, agents, context, hooks, commands, plugins, tokens, graph)
   Cloud              ahoy (login, logout, status, github, gitlab, billing, plans)
+  Design             designmd (lint, diff, export, init)
 
 Quick Start:
   $ buoy show all           # everything an AI agent needs
@@ -45,6 +47,9 @@ Quick Start:
 
   // === Cloud ===
   program.addCommand(createAhoyCommand());
+
+  // === Design ===
+  program.addCommand(createDesignMdCommand());
 
   return program;
 }

--- a/apps/cli/src/scan/__tests__/designmd-integration.test.ts
+++ b/apps/cli/src/scan/__tests__/designmd-integration.test.ts
@@ -1,0 +1,198 @@
+// apps/cli/src/scan/__tests__/designmd-integration.test.ts
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ScanOrchestrator } from "../orchestrator.js";
+import type { BuoyConfig } from "../../config/schema.js";
+
+// Mock scanners so the orchestrator runs end-to-end without hitting the file
+// system to discover components or tokens. The TokenScanner mock simulates a
+// CSS-discovered token in the same category that DESIGN.md owns (color), so
+// we can prove DESIGN.md REPLACES it rather than merging with it. We also
+// emit a token in a category DESIGN.md does NOT own (typography) to prove
+// it survives.
+const mockScanners = {
+  ReactComponentScanner: class {
+    scan() { return Promise.resolve({ items: [], errors: [] }); }
+  },
+  NextJSScanner: class {
+    scan() { return Promise.resolve({ items: [], errors: [] }); }
+  },
+  VueComponentScanner: class {
+    scan() { return Promise.resolve({ items: [], errors: [] }); }
+  },
+  SvelteComponentScanner: class {
+    scan() { return Promise.resolve({ items: [], errors: [] }); }
+  },
+  AngularComponentScanner: class {
+    scan() { return Promise.resolve({ items: [], errors: [] }); }
+  },
+  WebComponentScanner: class {
+    scan() { return Promise.resolve({ items: [], errors: [] }); }
+  },
+  TemplateScanner: class {
+    scan() { return Promise.resolve({ items: [], errors: [] }); }
+  },
+  TokenScanner: class {
+    scan() {
+      return Promise.resolve({
+        items: [
+          {
+            id: "css:src/tokens.css:color-from-css",
+            name: "color-from-css",
+            category: "color",
+            value: { type: "color", hex: "#aaaaaa" },
+            source: { type: "css", path: "src/tokens.css" },
+            aliases: [],
+            usedBy: [],
+            metadata: {},
+            scannedAt: new Date(),
+          },
+          {
+            id: "css:src/tokens.css:font-body",
+            name: "font-body",
+            category: "typography",
+            value: {
+              type: "typography",
+              fontFamily: "Inter",
+              fontSize: 16,
+              fontWeight: 400,
+            },
+            source: { type: "css", path: "src/tokens.css" },
+            aliases: [],
+            usedBy: [],
+            metadata: {},
+            scannedAt: new Date(),
+          },
+        ],
+        errors: [],
+      });
+    }
+  },
+};
+
+vi.mock("@buoy-design/scanners/git", () => mockScanners);
+vi.mock("@buoy-design/scanners/figma", () => ({
+  FigmaComponentScanner: class {
+    scan() { return Promise.resolve({ items: [], errors: [] }); }
+  },
+}));
+vi.mock("@buoy-design/scanners/storybook", () => ({
+  StorybookScanner: class {
+    scan() { return Promise.resolve({ items: [], errors: [] }); }
+  },
+}));
+
+let dir: string;
+
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), "buoy-designmd-"));
+  mkdirSync(join(dir, "src"), { recursive: true });
+  writeFileSync(
+    join(dir, "src", "tokens.css"),
+    `:root {\n  --color-from-css: #aaaaaa;\n}\n`,
+  );
+  writeFileSync(
+    join(dir, "DESIGN.md"),
+    `---
+name: Test
+colors:
+  primary: "#1a1c1e"
+spacing:
+  md: 16px
+rounded:
+  md: 8px
+---
+
+## Overview
+
+Fixture.
+`,
+  );
+});
+
+afterAll(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+const minimalConfig: BuoyConfig = {
+  project: { name: "test-project" },
+  sources: {
+    tokens: {
+      enabled: true,
+      files: ["src/tokens.css"],
+    },
+  },
+  drift: { ignore: [], severity: {} },
+  claude: { enabled: false, model: "claude-sonnet-4-20250514" },
+  output: { format: "table", colors: true },
+} as BuoyConfig;
+
+describe("DESIGN.md scanner integration", () => {
+  it("replaces CSS-discovered tokens with DESIGN.md tokens when both exist", async () => {
+    const orchestrator = new ScanOrchestrator(minimalConfig, dir);
+    const result = await orchestrator.scan({ sources: ["tokens"] });
+
+    // DESIGN.md tokens must be present
+    expect(
+      result.tokens.some(
+        (t) => t.name === "primary" && t.category === "color",
+      ),
+    ).toBe(true);
+    expect(
+      result.tokens.some(
+        (t) => t.name === "md" && t.category === "spacing",
+      ),
+    ).toBe(true);
+    expect(
+      result.tokens.some((t) => t.name === "md" && t.category === "other"),
+    ).toBe(true);
+
+    // CSS-discovered token in an OWNED category must NOT be present
+    expect(
+      result.tokens.some((t) => t.name === "color-from-css"),
+    ).toBe(false);
+
+    // CSS-discovered token in a NON-owned category (typography) MUST survive
+    expect(
+      result.tokens.some(
+        (t) => t.name === "font-body" && t.category === "typography",
+      ),
+    ).toBe(true);
+
+    // Surface flag is set
+    expect(
+      (result as typeof result & { designMdApplied?: boolean })
+        .designMdApplied,
+    ).toBe(true);
+  });
+
+  it("leaves CSS-discovered tokens intact when no DESIGN.md is present", async () => {
+    const noDesignDir = mkdtempSync(join(tmpdir(), "buoy-no-designmd-"));
+    try {
+      const orchestrator = new ScanOrchestrator(minimalConfig, noDesignDir);
+      const result = await orchestrator.scan({ sources: ["tokens"] });
+
+      // Original CSS-discovered tokens preserved
+      expect(
+        result.tokens.some((t) => t.name === "color-from-css"),
+      ).toBe(true);
+      expect(
+        result.tokens.some((t) => t.name === "font-body"),
+      ).toBe(true);
+
+      // DESIGN.md tokens NOT injected
+      expect(
+        result.tokens.some((t) => t.name === "primary"),
+      ).toBe(false);
+
+      expect(
+        (result as typeof result & { designMdApplied?: boolean })
+          .designMdApplied,
+      ).toBe(false);
+    } finally {
+      rmSync(noDesignDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/cli/src/scan/orchestrator.ts
+++ b/apps/cli/src/scan/orchestrator.ts
@@ -359,6 +359,13 @@ export class ScanOrchestrator {
     // (color/spacing/other). Other categories (typography, shadow, etc.) are
     // untouched. If DESIGN.md is absent or fails to parse cleanly, behavior
     // is unchanged.
+    //
+    // This step runs unconditionally — regardless of which `sources` were
+    // explicitly requested. DESIGN.md represents design intent, and drift
+    // detection benefits from that intent even when the caller only asked
+    // for component scans (e.g. `scan({ sources: ["react"] })`). If you
+    // need a path that strictly avoids touching DESIGN.md, gate the call
+    // here on the source filter — but that has not been a real ask yet.
     const designMdResult = await this.applyDesignMdPrecedence(result.tokens);
     result.tokens = designMdResult.tokens;
     (result as ScanResult & { designMdApplied?: boolean }).designMdApplied =

--- a/apps/cli/src/scan/orchestrator.ts
+++ b/apps/cli/src/scan/orchestrator.ts
@@ -1,5 +1,8 @@
 // apps/cli/src/scan/orchestrator.ts
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import type { Component, DesignToken } from "@buoy-design/core";
+import { parseDesignMd, designMdToTokens } from "@buoy-design/core";
 import type { ScanCache } from "@buoy-design/scanners";
 import type { BuoyConfig, SourcesConfig } from "../config/schema.js";
 
@@ -351,7 +354,49 @@ export class ScanOrchestrator {
       result.cacheStats = { hits: totalCacheHits, misses: totalCacheMisses };
     }
 
+    // DESIGN.md precedence: when a DESIGN.md exists at the project root, its
+    // tokens replace the auto-discovered ones for owned categories
+    // (color/spacing/other). Other categories (typography, shadow, etc.) are
+    // untouched. If DESIGN.md is absent or fails to parse cleanly, behavior
+    // is unchanged.
+    const designMdResult = await this.applyDesignMdPrecedence(result.tokens);
+    result.tokens = designMdResult.tokens;
+    (result as ScanResult & { designMdApplied?: boolean }).designMdApplied =
+      designMdResult.applied;
+
     return result;
+  }
+
+  /**
+   * If a DESIGN.md exists at the project root, parse it and replace tokens
+   * of categories owned by DESIGN.md (color, spacing, other) with the
+   * projection. Returns the original tokens unchanged when no DESIGN.md is
+   * present or it parses with errors.
+   */
+  private async applyDesignMdPrecedence(
+    tokens: DesignToken[],
+  ): Promise<{ tokens: DesignToken[]; applied: boolean }> {
+    const designMdPath = join(this.projectRoot, "DESIGN.md");
+    if (!existsSync(designMdPath)) return { tokens, applied: false };
+
+    const source = readFileSync(designMdPath, "utf8");
+    const parsed = parseDesignMd(source);
+
+    // If parse produced errors, skip the precedence step (don't break scans
+    // on a broken DESIGN.md).
+    if (parsed.summary.errors > 0) return { tokens, applied: false };
+
+    const designMdTokens = designMdToTokens(parsed.designSystem);
+    if (designMdTokens.length === 0) return { tokens, applied: false };
+
+    const ownedCategories = new Set<DesignToken["category"]>([
+      "color",
+      "spacing",
+      "other",
+    ]);
+
+    const kept = tokens.filter((t) => !ownedCategories.has(t.category));
+    return { tokens: [...kept, ...designMdTokens], applied: true };
   }
 
   /**

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,6 +53,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@google/design.md": "0.1.1",
     "glob": "^11.0.0",
     "graphology": "^0.26.0",
     "graphology-types": "^0.24.8",

--- a/packages/core/src/designmd/adapter.test.ts
+++ b/packages/core/src/designmd/adapter.test.ts
@@ -7,7 +7,7 @@ vi.mock("@google/design.md/linter", async (importOriginal) => {
 });
 
 import { lint } from "@google/design.md/linter";
-import { parseDesignMd, type DesignMdResult } from "./adapter.js";
+import { parseDesignMd, type DesignMdResult } from "./index.js";
 
 const FIXTURE = `---
 name: Heritage

--- a/packages/core/src/designmd/adapter.test.ts
+++ b/packages/core/src/designmd/adapter.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { parseDesignMd, type DesignMdResult } from "./adapter.js";
+
+const FIXTURE = `---
+name: Heritage
+colors:
+  primary: "#1A1C1E"
+  tertiary: "#B8422E"
+spacing:
+  md: 16px
+---
+
+## Overview
+
+A test fixture.
+`;
+
+describe("parseDesignMd", () => {
+  it("parses tokens, findings, and summary from a valid DESIGN.md", () => {
+    const result: DesignMdResult = parseDesignMd(FIXTURE);
+
+    expect(result.designSystem.name).toBe("Heritage");
+    // Upstream linter lowercases hex values during parse.
+    expect(result.designSystem.colors?.primary?.toLowerCase()).toBe("#1a1c1e");
+    expect(result.designSystem.spacing?.md).toBe("16px");
+
+    expect(result.summary).toEqual(
+      expect.objectContaining({ errors: expect.any(Number) })
+    );
+    expect(Array.isArray(result.findings)).toBe(true);
+  });
+
+  it("returns errors for malformed front matter", () => {
+    const broken = `---\ncolors:\n  primary: not-a-hex\n---\n`;
+    const result = parseDesignMd(broken);
+    // Either lint surfaces the bad value as a finding, or parse rejects.
+    // Adapter contract: never throws — always returns a result.
+    expect(result.summary.errors + result.summary.warnings).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/src/designmd/adapter.test.ts
+++ b/packages/core/src/designmd/adapter.test.ts
@@ -1,4 +1,12 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@google/design.md/linter", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@google/design.md/linter")>();
+  return { ...actual, lint: vi.fn(actual.lint) };
+});
+
+import { lint } from "@google/design.md/linter";
 import { parseDesignMd, type DesignMdResult } from "./adapter.js";
 
 const FIXTURE = `---
@@ -16,6 +24,11 @@ A test fixture.
 `;
 
 describe("parseDesignMd", () => {
+  beforeEach(() => {
+    vi.mocked(lint).mockClear();
+    // Factory wraps the real implementation; mockClear preserves it.
+  });
+
   it("parses tokens, findings, and summary from a valid DESIGN.md", () => {
     const result: DesignMdResult = parseDesignMd(FIXTURE);
 
@@ -36,5 +49,20 @@ describe("parseDesignMd", () => {
     // Either lint surfaces the bad value as a finding, or parse rejects.
     // Adapter contract: never throws — always returns a result.
     expect(result.summary.errors + result.summary.warnings).toBeGreaterThan(0);
+  });
+
+  it("returns a synthetic parse-error finding when lint() throws", () => {
+    vi.mocked(lint).mockImplementationOnce(() => {
+      throw new Error("upstream blew up");
+    });
+    const result = parseDesignMd("---\nname: anything\n---\n");
+    expect(result.summary.errors).toBe(1);
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0]).toEqual({
+      rule: "parse-error",
+      severity: "error",
+      path: "",
+      message: "upstream blew up",
+    });
   });
 });

--- a/packages/core/src/designmd/adapter.ts
+++ b/packages/core/src/designmd/adapter.ts
@@ -1,0 +1,168 @@
+import { lint } from "@google/design.md/linter";
+import type {
+  DesignMdResult,
+  DesignMdFinding,
+  DesignMdSummary,
+  DesignMdSystem,
+  DesignMdToken,
+} from "./types.js";
+
+type AnyRec = Record<string, unknown>;
+
+function mapToRecord<V>(m: unknown): Record<string, V> | undefined {
+  if (m instanceof Map) return Object.fromEntries(m) as Record<string, V>;
+  if (m && typeof m === "object") return m as Record<string, V>;
+  return undefined;
+}
+
+function dimensionToString(v: unknown): string | undefined {
+  if (typeof v === "string") return v;
+  if (v && typeof v === "object") {
+    const o = v as AnyRec;
+    if (typeof o.value === "number" && typeof o.unit === "string") {
+      return `${o.value}${o.unit}`;
+    }
+  }
+  return undefined;
+}
+
+function colorsRecord(m: unknown): Record<string, string> | undefined {
+  const rec = mapToRecord<unknown>(m);
+  if (!rec) return undefined;
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(rec)) {
+    if (v && typeof v === "object" && typeof (v as AnyRec).hex === "string") {
+      out[k] = (v as AnyRec).hex as string;
+    } else if (typeof v === "string") {
+      out[k] = v;
+    }
+  }
+  return out;
+}
+
+function dimensionsRecord(m: unknown): Record<string, string> | undefined {
+  const rec = mapToRecord<unknown>(m);
+  if (!rec) return undefined;
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(rec)) {
+    const s = dimensionToString(v);
+    if (s !== undefined) out[k] = s;
+  }
+  return out;
+}
+
+function typographyRecord(
+  m: unknown
+): Record<string, DesignMdToken> | undefined {
+  const rec = mapToRecord<unknown>(m);
+  if (!rec) return undefined;
+  const out: Record<string, DesignMdToken> = {};
+  for (const [k, v] of Object.entries(rec)) {
+    if (v && typeof v === "object") out[k] = v as DesignMdToken;
+  }
+  return out;
+}
+
+function componentsRecord(
+  m: unknown
+): Record<string, Record<string, string>> | undefined {
+  const rec = mapToRecord<unknown>(m);
+  if (!rec) return undefined;
+  const out: Record<string, Record<string, string>> = {};
+  for (const [k, v] of Object.entries(rec)) {
+    const props = (v as AnyRec)?.properties;
+    const propRec = mapToRecord<unknown>(props);
+    if (!propRec) continue;
+    const inner: Record<string, string> = {};
+    for (const [pk, pv] of Object.entries(propRec)) {
+      if (typeof pv === "string") inner[pk] = pv;
+      else {
+        const s = dimensionToString(pv);
+        if (s !== undefined) inner[pk] = s;
+        else if (pv && typeof pv === "object" && typeof (pv as AnyRec).hex === "string") {
+          inner[pk] = (pv as AnyRec).hex as string;
+        }
+      }
+    }
+    out[k] = inner;
+  }
+  return out;
+}
+
+function normalizeDesignSystem(raw: unknown): DesignMdSystem {
+  const r = (raw ?? {}) as AnyRec;
+  const sys: DesignMdSystem = {};
+  if (typeof r.version === "string") sys.version = r.version;
+  if (typeof r.name === "string") sys.name = r.name;
+  if (typeof r.description === "string") sys.description = r.description;
+  const colors = colorsRecord(r.colors);
+  if (colors) sys.colors = colors;
+  const typography = typographyRecord(r.typography);
+  if (typography) sys.typography = typography;
+  const rounded = dimensionsRecord(r.rounded);
+  if (rounded) sys.rounded = rounded;
+  const spacing = dimensionsRecord(r.spacing);
+  if (spacing) sys.spacing = spacing;
+  const components = componentsRecord(r.components);
+  if (components) sys.components = components;
+  return sys;
+}
+
+function normalizeFindings(raw: unknown): DesignMdFinding[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.map((f) => {
+    const o = (f ?? {}) as AnyRec;
+    return {
+      rule: typeof o.rule === "string" ? o.rule : "",
+      severity: (o.severity as DesignMdFinding["severity"]) ?? "info",
+      path: typeof o.path === "string" ? o.path : "",
+      message: typeof o.message === "string" ? o.message : "",
+    };
+  });
+}
+
+function normalizeSummary(raw: unknown): DesignMdSummary {
+  const o = (raw ?? {}) as AnyRec;
+  const errors = typeof o.errors === "number" ? o.errors : 0;
+  const warnings = typeof o.warnings === "number" ? o.warnings : 0;
+  // Upstream uses `infos`; we expose `info`.
+  const infoVal =
+    typeof o.info === "number"
+      ? o.info
+      : typeof o.infos === "number"
+        ? o.infos
+        : 0;
+  return { errors, warnings, info: infoVal };
+}
+
+/**
+ * Parse and lint a DESIGN.md source string. Never throws — failures surface
+ * as findings with severity "error".
+ */
+export function parseDesignMd(source: string): DesignMdResult {
+  try {
+    const report = lint(source) as unknown as AnyRec;
+    return {
+      designSystem: normalizeDesignSystem(report.designSystem),
+      findings: normalizeFindings(report.findings),
+      summary: normalizeSummary(report.summary),
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      designSystem: {},
+      findings: [
+        { rule: "parse-error", severity: "error", path: "", message },
+      ],
+      summary: { errors: 1, warnings: 0, info: 0 },
+    };
+  }
+}
+
+export type {
+  DesignMdResult,
+  DesignMdFinding,
+  DesignMdSummary,
+  DesignMdSystem,
+  DesignMdSeverity,
+} from "./types.js";

--- a/packages/core/src/designmd/adapter.ts
+++ b/packages/core/src/designmd/adapter.ts
@@ -2,6 +2,7 @@ import { lint } from "@google/design.md/linter";
 import type {
   DesignMdResult,
   DesignMdFinding,
+  DesignMdSeverity,
   DesignMdSummary,
   DesignMdSystem,
   DesignMdToken,
@@ -112,9 +113,12 @@ function normalizeFindings(raw: unknown): DesignMdFinding[] {
   if (!Array.isArray(raw)) return [];
   return raw.map((f) => {
     const o = (f ?? {}) as AnyRec;
+    const sev = o.severity;
+    const severity: DesignMdSeverity =
+      sev === "error" || sev === "warning" || sev === "info" ? sev : "info";
     return {
       rule: typeof o.rule === "string" ? o.rule : "",
-      severity: (o.severity as DesignMdFinding["severity"]) ?? "info",
+      severity,
       path: typeof o.path === "string" ? o.path : "",
       message: typeof o.message === "string" ? o.message : "",
     };

--- a/packages/core/src/designmd/adapter.ts
+++ b/packages/core/src/designmd/adapter.ts
@@ -162,11 +162,3 @@ export function parseDesignMd(source: string): DesignMdResult {
     };
   }
 }
-
-export type {
-  DesignMdResult,
-  DesignMdFinding,
-  DesignMdSummary,
-  DesignMdSystem,
-  DesignMdSeverity,
-} from "./types.js";

--- a/packages/core/src/designmd/index.ts
+++ b/packages/core/src/designmd/index.ts
@@ -1,2 +1,3 @@
 export * from "./types.js";
 export { parseDesignMd } from "./adapter.js";
+export { designMdToTokens } from "./to-tokens.js";

--- a/packages/core/src/designmd/index.ts
+++ b/packages/core/src/designmd/index.ts
@@ -1,0 +1,2 @@
+export * from "./types.js";
+export { parseDesignMd } from "./adapter.js";

--- a/packages/core/src/designmd/to-tokens.test.ts
+++ b/packages/core/src/designmd/to-tokens.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { designMdToTokens } from "./to-tokens.js";
+import type { DesignMdSystem } from "./types.js";
+
+describe("designMdToTokens", () => {
+  it("projects colors to DesignToken[] with category 'color'", () => {
+    const ds: DesignMdSystem = {
+      colors: { primary: "#1a1c1e", secondary: "#6c7278" },
+    };
+    const tokens = designMdToTokens(ds);
+    expect(tokens).toHaveLength(2);
+
+    const primary = tokens.find((t) => t.name === "primary");
+    expect(primary?.category).toBe("color");
+    expect(primary?.value).toEqual({ type: "color", hex: "#1a1c1e" });
+    expect(primary?.source).toEqual({ type: "css", path: "DESIGN.md" });
+  });
+
+  it("projects spacing strings to DesignToken[] with category 'spacing'", () => {
+    const ds: DesignMdSystem = {
+      spacing: { md: "16px", lg: "24px" },
+    };
+    const tokens = designMdToTokens(ds);
+    const md = tokens.find((t) => t.name === "md");
+    expect(md?.category).toBe("spacing");
+    expect(md?.value).toEqual({ type: "spacing", value: 16, unit: "px" });
+  });
+
+  it("supports rem and em units in spacing", () => {
+    const ds: DesignMdSystem = { spacing: { sm: "0.5rem", xs: "0.25em" } };
+    const tokens = designMdToTokens(ds);
+    expect(tokens.find((t) => t.name === "sm")?.value).toEqual({
+      type: "spacing",
+      value: 0.5,
+      unit: "rem",
+    });
+    expect(tokens.find((t) => t.name === "xs")?.value).toEqual({
+      type: "spacing",
+      value: 0.25,
+      unit: "em",
+    });
+  });
+
+  it("projects rounded values to category 'other' with raw value", () => {
+    const ds: DesignMdSystem = { rounded: { md: "8px", lg: "12px" } };
+    const tokens = designMdToTokens(ds);
+    const md = tokens.find((t) => t.name === "md");
+    expect(md?.category).toBe("other");
+    expect(md?.value).toEqual({ type: "raw", value: "8px" });
+  });
+
+  it("skips typography and components for v1", () => {
+    const ds: DesignMdSystem = {
+      typography: { h1: { fontFamily: "x" } },
+      components: { button: { backgroundColor: "y" } },
+    };
+    const tokens = designMdToTokens(ds);
+    expect(tokens).toHaveLength(0);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(designMdToTokens({})).toEqual([]);
+  });
+
+  it("skips spacing values that don't parse", () => {
+    const ds: DesignMdSystem = { spacing: { weird: "not-a-dimension" } };
+    expect(designMdToTokens(ds)).toEqual([]);
+  });
+});

--- a/packages/core/src/designmd/to-tokens.ts
+++ b/packages/core/src/designmd/to-tokens.ts
@@ -1,0 +1,66 @@
+import type { DesignMdSystem } from "./types.js";
+import type { DesignToken } from "../models/token.js";
+
+const DIMENSION_RE = /^(-?\d*\.?\d+)(px|rem|em)$/;
+
+function parseDimension(
+  input: string,
+): { value: number; unit: "px" | "rem" | "em" } | null {
+  const m = DIMENSION_RE.exec(input.trim());
+  if (!m) return null;
+  return { value: parseFloat(m[1]!), unit: m[2] as "px" | "rem" | "em" };
+}
+
+function makeBaseToken(
+  name: string,
+  category: DesignToken["category"],
+): Omit<DesignToken, "value"> {
+  return {
+    id: `designmd:${category}:${name}`,
+    name,
+    category,
+    source: { type: "css", path: "DESIGN.md" },
+    aliases: [],
+    usedBy: [],
+    metadata: {},
+    scannedAt: new Date(),
+  };
+}
+
+/**
+ * Project a DESIGN.md design system to Buoy's DesignToken[] shape.
+ *
+ * v1 supports: colors, spacing, rounded.
+ * Skipped: typography (complex shape), components (deferred).
+ *
+ * Note: rounded values are mapped to category "other" with `value: { type: "raw" }`
+ * because there is no `radius`/`rounded` category in the existing token schema.
+ */
+export function designMdToTokens(ds: DesignMdSystem): DesignToken[] {
+  const out: DesignToken[] = [];
+
+  for (const [name, hex] of Object.entries(ds.colors ?? {})) {
+    out.push({
+      ...makeBaseToken(name, "color"),
+      value: { type: "color", hex: String(hex) },
+    });
+  }
+
+  for (const [name, raw] of Object.entries(ds.spacing ?? {})) {
+    const dim = parseDimension(String(raw));
+    if (!dim) continue;
+    out.push({
+      ...makeBaseToken(name, "spacing"),
+      value: { type: "spacing", value: dim.value, unit: dim.unit },
+    });
+  }
+
+  for (const [name, raw] of Object.entries(ds.rounded ?? {})) {
+    out.push({
+      ...makeBaseToken(name, "other"),
+      value: { type: "raw", value: String(raw) },
+    });
+  }
+
+  return out;
+}

--- a/packages/core/src/designmd/types.ts
+++ b/packages/core/src/designmd/types.ts
@@ -1,0 +1,40 @@
+/**
+ * Buoy-facing types that mirror @google/design.md/linter shapes.
+ * Re-exported here so consumers don't import upstream directly.
+ */
+
+export interface DesignMdToken {
+  [key: string]: unknown;
+}
+
+export interface DesignMdSystem {
+  version?: string;
+  name?: string;
+  description?: string;
+  colors?: Record<string, string>;
+  typography?: Record<string, DesignMdToken>;
+  rounded?: Record<string, string>;
+  spacing?: Record<string, string | number>;
+  components?: Record<string, Record<string, string>>;
+}
+
+export type DesignMdSeverity = "error" | "warning" | "info";
+
+export interface DesignMdFinding {
+  rule: string;
+  severity: DesignMdSeverity;
+  path: string;
+  message: string;
+}
+
+export interface DesignMdSummary {
+  errors: number;
+  warnings: number;
+  info: number;
+}
+
+export interface DesignMdResult {
+  designSystem: DesignMdSystem;
+  findings: DesignMdFinding[];
+  summary: DesignMdSummary;
+}

--- a/packages/core/src/designmd/types.ts
+++ b/packages/core/src/designmd/types.ts
@@ -14,7 +14,7 @@ export interface DesignMdSystem {
   colors?: Record<string, string>;
   typography?: Record<string, DesignMdToken>;
   rounded?: Record<string, string>;
-  spacing?: Record<string, string | number>;
+  spacing?: Record<string, string>;
   components?: Record<string, Record<string, string>>;
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,6 +16,9 @@ export * from './plugins/index.js';
 // Re-export token parsing
 export * from './tokens/index.js';
 
+// Re-export DESIGN.md adapter
+export * from './designmd/index.js';
+
 // Re-export graph
 export * from './graph/index.js';
 

--- a/packages/scanners/package.json
+++ b/packages/scanners/package.json
@@ -60,6 +60,7 @@
   },
   "dependencies": {
     "@buoy-design/core": "workspace:*",
+    "@google/design.md": "0.1.1",
     "glob": "^11.0.0",
     "typescript": "^5.7.2",
     "zod": "^3.24.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@buoy-design/scanners':
         specifier: workspace:*
         version: link:../../packages/scanners
+      '@google/design.md':
+        specifier: 0.1.1
+        version: 0.1.1
       '@inquirer/prompts':
         specifier: ^8.1.0
         version: 8.1.0(@types/node@22.19.3)
@@ -58,7 +61,7 @@ importers:
         version: 12.1.0
       drizzle-orm:
         specifier: ^0.38.3
-        version: 0.38.4(@cloudflare/workers-types@4.20260103.0)(@types/better-sqlite3@7.6.13)(@types/react@18.3.27)(better-sqlite3@11.10.0)(react@18.3.1)
+        version: 0.38.4(@cloudflare/workers-types@4.20260103.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(react@19.2.5)
       glob:
         specifier: ^11.0.0
         version: 11.1.0
@@ -102,6 +105,9 @@ importers:
 
   packages/core:
     dependencies:
+      '@google/design.md':
+        specifier: 0.1.1
+        version: 0.1.1
       glob:
         specifier: ^11.0.0
         version: 11.1.0
@@ -127,6 +133,9 @@ importers:
       '@buoy-design/core':
         specifier: workspace:*
         version: link:../core
+      '@google/design.md':
+        specifier: 0.1.1
+        version: 0.1.1
       glob:
         specifier: ^11.0.0
         version: 11.1.0
@@ -145,6 +154,10 @@ importers:
         version: 4.51.1
 
 packages:
+
+  '@alcalzone/ansi-tokenize@0.3.0':
+    resolution: {integrity: sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA==}
+    engines: {node: '>=18'}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -414,6 +427,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@google/design.md@0.1.1':
+    resolution: {integrity: sha512-S5xdF4DrELQwY2186vishZ9ZHxzMo7eikM8FHFNDS87oULElLDF5eko33DPCXtWyzEPyzkZWuUTpm/M0pPtbNQ==}
+    hasBin: true
+
   '@inquirer/ansi@2.0.2':
     resolution: {integrity: sha512-SYLX05PwJVnW+WVegZt1T4Ip1qba1ik+pNJPDiqvk6zS5Y/i8PhRzLpGEtVd7sW0G8cMtkD8t4AZYhQwm8vnww==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
@@ -585,6 +602,17 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@json-render/core@0.16.0':
+    resolution: {integrity: sha512-qQp8BB/3pWYapTGXBDSBMXRCdrC05VJPLL3drXMPX/QbUB3nuvtyXUGmAZFUz8eLUy7JImODvb3GNIq38dGzhQ==}
+    peerDependencies:
+      zod: ^4.0.0
+
+  '@json-render/ink@0.16.0':
+    resolution: {integrity: sha512-oJ/MbW0zLkv3i6MSZVk8QiI6mbyvtA0XZpJEuJBTCf1yjMMdxN16Mz/uW/5AV9FMOBjZXohQPONLMxvSxil6Bg==}
+    peerDependencies:
+      ink: ^6.0.0
+      react: ^19.0.0
 
   '@jsonjoy.com/base64@1.1.2':
     resolution: {integrity: sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==}
@@ -821,8 +849,23 @@ packages:
   '@types/better-sqlite3@7.6.13':
     resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
@@ -830,11 +873,11 @@ packages:
   '@types/node@22.19.3':
     resolution: {integrity: sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==}
 
-  '@types/prop-types@15.7.15':
-    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
-  '@types/react@18.3.27':
-    resolution: {integrity: sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==}
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@vitest/coverage-v8@2.1.9':
     resolution: {integrity: sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==}
@@ -874,6 +917,16 @@ packages:
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -881,6 +934,10 @@ packages:
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
+
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -914,6 +971,13 @@ packages:
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  auto-bind@5.0.1:
+    resolution: {integrity: sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -959,6 +1023,9 @@ packages:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
@@ -966,6 +1033,18 @@ packages:
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
@@ -981,6 +1060,17 @@ packages:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
 
+  citty@0.1.6:
+    resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
+
+  cli-boxes@4.0.1:
+    resolution: {integrity: sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw==}
+    engines: {node: '>=18.20 <19 || >=20.10'}
+
+  cli-cursor@4.0.0:
+    resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
     engines: {node: '>=18'}
@@ -993,9 +1083,17 @@ packages:
     resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
     engines: {node: 10.* || >= 12.*}
 
+  cli-truncate@6.0.0:
+    resolution: {integrity: sha512-3+YKIUFsohD9MIoOFPFBldjAlnfCmCDcqe6aYGFqlDTRKg80p4wg35L+j83QQ63iOlKRccEkbn8IuM++HsgEjA==}
+    engines: {node: '>=22'}
+
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
+
+  code-excerpt@4.0.0:
+    resolution: {integrity: sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -1012,6 +1110,14 @@ packages:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
 
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  convert-to-spaces@2.0.1:
+    resolution: {integrity: sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1019,9 +1125,6 @@ packages:
   cssstyle@4.6.0:
     resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
     engines: {node: '>=18'}
-
-  csstype@3.2.3:
-    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   data-urls@5.0.0:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
@@ -1038,6 +1141,9 @@ packages:
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
@@ -1067,6 +1173,10 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
@@ -1074,6 +1184,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -1198,6 +1311,10 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
+
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
@@ -1217,15 +1334,32 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
+  es-toolkit@1.46.1:
+    resolution: {integrity: sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==}
+
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
     hasBin: true
 
+  escape-string-regexp@2.0.0:
+    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
+    engines: {node: '>=8'}
+
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
+
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
+  estree-util-visit@2.0.0:
+    resolution: {integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -1242,6 +1376,9 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
 
@@ -1254,6 +1391,9 @@ packages:
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
+  fault@2.0.1:
+    resolution: {integrity: sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==}
 
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
@@ -1273,6 +1413,10 @@ packages:
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
+
+  format@0.2.2:
+    resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
+    engines: {node: '>=0.4.x'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -1295,6 +1439,10 @@ packages:
 
   get-east-asian-width@1.4.0:
     resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
+    engines: {node: '>=18'}
+
+  get-east-asian-width@1.5.0:
+    resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
     engines: {node: '>=18'}
 
   get-intrinsic@1.3.0:
@@ -1402,11 +1550,37 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
+  indent-string@5.0.0:
+    resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
+    engines: {node: '>=12'}
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  ink@7.0.1:
+    resolution: {integrity: sha512-o6LAC268PLawlGVYrXTyaTfke4VtJftEheuwbgkQf7yvSXyWp1nRwBbAyKEkWXFZZsW/la5wrMuNbuBvZK2C1w==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      '@types/react': '>=19.2.0'
+      react: '>=19.2.0'
+      react-devtools-core: '>=6.1.2'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react-devtools-core:
+        optional: true
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
   is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
@@ -1421,9 +1595,21 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
+
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
+  is-in-ci@2.0.0:
+    resolution: {integrity: sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   is-in-ssh@1.0.0:
     resolution: {integrity: sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==}
@@ -1441,6 +1627,10 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -1491,9 +1681,6 @@ packages:
     resolution: {integrity: sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==}
     engines: {node: 20 || >=22}
 
-  js-tokens@4.0.0:
-    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
   js-yaml@3.14.2:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
     hasBin: true
@@ -1529,9 +1716,8 @@ packages:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
     engines: {node: '>=18'}
 
-  loose-envify@1.4.0:
-    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
-    hasBin: true
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
@@ -1553,9 +1739,45 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
+  marked@17.0.6:
+    resolution: {integrity: sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-frontmatter@2.0.1:
+    resolution: {integrity: sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdx@3.0.0:
+    resolution: {integrity: sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  mdast@3.0.0:
+    resolution: {integrity: sha512-xySmf8g4fPKMeC07jXGz971EkLbWAJ83s4US2Tj9lEdnZ142UP5grN73H1Xd3HzrdbU5o9GYYP/y8F9ZSwLE9g==}
+    deprecated: '`mdast` was renamed to `remark`'
 
   memfs@4.51.1:
     resolution: {integrity: sha512-Eyt3XrufitN2ZL9c/uIRMyDwXanLI88h/L3MoWqNY747ha3dMR9dWqp8cRT5ntjZ0U1TNuq4U91ZXK0sMBjYOQ==}
@@ -1563,6 +1785,93 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-frontmatter@2.0.0:
+    resolution: {integrity: sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==}
+
+  micromark-extension-mdx-expression@3.0.1:
+    resolution: {integrity: sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==}
+
+  micromark-extension-mdx-jsx@3.0.2:
+    resolution: {integrity: sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==}
+
+  micromark-extension-mdx-md@2.0.0:
+    resolution: {integrity: sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==}
+
+  micromark-extension-mdxjs-esm@3.0.0:
+    resolution: {integrity: sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==}
+
+  micromark-extension-mdxjs@3.0.0:
+    resolution: {integrity: sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-mdx-expression@2.0.3:
+    resolution: {integrity: sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-events-to-acorn@2.0.3:
+    resolution: {integrity: sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -1575,6 +1884,10 @@ packages:
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
 
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
@@ -1631,6 +1944,10 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
+
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
@@ -1672,8 +1989,15 @@ packages:
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
 
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
+  patch-console@2.0.0:
+    resolution: {integrity: sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -1760,8 +2084,14 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
-  react@18.3.1:
-    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+  react-reconciler@0.33.0:
+    resolution: {integrity: sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: ^19.2.0
+
+  react@19.2.5:
+    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
 
   read-yaml-file@1.1.0:
@@ -1772,12 +2102,28 @@ packages:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
 
+  remark-frontmatter@5.0.0:
+    resolution: {integrity: sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==}
+
+  remark-mdx@3.1.1:
+    resolution: {integrity: sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
+
+  restore-cursor@4.0.0:
+    resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
@@ -1815,6 +2161,9 @@ packages:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
 
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
   semver@7.7.3:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
     engines: {node: '>=10'}
@@ -1830,6 +2179,9 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
@@ -1848,6 +2200,10 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
+  slice-ansi@9.0.0:
+    resolution: {integrity: sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==}
+    engines: {node: '>=22'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1857,6 +2213,10 @@ packages:
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  stack-utils@2.0.6:
+    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
+    engines: {node: '>=10'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -1880,8 +2240,15 @@ packages:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
 
+  string-width@8.2.1:
+    resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
+    engines: {node: '>=20'}
+
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -1906,6 +2273,10 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   tar-fs@2.1.4:
     resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
 
@@ -1916,6 +2287,10 @@ packages:
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
+
+  terminal-size@4.0.1:
+    resolution: {integrity: sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ==}
+    engines: {node: '>=18'}
 
   test-exclude@7.0.1:
     resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
@@ -1963,6 +2338,9 @@ packages:
     peerDependencies:
       tslib: '2'
 
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
@@ -2006,6 +2384,10 @@ packages:
     resolution: {integrity: sha512-5JIA5aYBAJSAhrhbyag1ZuMSgUZnHtI+Sq3H8D3an4fL8PeF+L1yYvbEJg47akP1PFfATMf5ehkqFnxfkmuwZQ==}
     hasBin: true
 
+  type-fest@5.6.0:
+    resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
+    engines: {node: '>=20'}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -2013,6 +2395,24 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position-from-estree@2.0.0:
+    resolution: {integrity: sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
   universal-user-agent@7.0.3:
     resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
@@ -2030,6 +2430,12 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
@@ -2123,6 +2529,14 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  widest-line@6.0.0:
+    resolution: {integrity: sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA==}
+    engines: {node: '>=20'}
+
+  wrap-ansi@10.0.0:
+    resolution: {integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==}
+    engines: {node: '>=20'}
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -2138,8 +2552,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.18.0:
-    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -2166,6 +2580,9 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  yoga-layout@3.2.1:
+    resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
+
   zod-validation-error@5.0.0:
     resolution: {integrity: sha512-hmk+pkyKq7Q71PiWVSDUc3VfpzpvcRHZ3QPw9yEMVvmtCekaMeOHnbr3WbxfrgEnQTv6haGP4cmv0Ojmihzsxw==}
     engines: {node: '>=18.0.0'}
@@ -2178,7 +2595,15 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+
 snapshots:
+
+  '@alcalzone/ansi-tokenize@0.3.0':
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
 
   '@ampproject/remapping@2.3.0':
     dependencies:
@@ -2461,6 +2886,29 @@ snapshots:
   '@esbuild/win32-x64@0.21.5':
     optional: true
 
+  '@google/design.md@0.1.1':
+    dependencies:
+      '@json-render/core': 0.16.0(zod@3.25.76)
+      '@json-render/ink': 0.16.0(ink@7.0.1(react@19.2.5))(react@19.2.5)(zod@3.25.76)
+      citty: 0.1.6
+      ink: 7.0.1(react@19.2.5)
+      mdast: 3.0.0
+      react: 19.2.5
+      remark-frontmatter: 5.0.0
+      remark-mdx: 3.1.1
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      yaml: 2.8.2
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@types/react'
+      - bufferutil
+      - react-devtools-core
+      - supports-color
+      - utf-8-validate
+
   '@inquirer/ansi@2.0.2': {}
 
   '@inquirer/checkbox@5.0.3(@types/node@22.19.3)':
@@ -2617,6 +3065,19 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@json-render/core@0.16.0(zod@3.25.76)':
+    dependencies:
+      zod: 3.25.76
+
+  '@json-render/ink@0.16.0(ink@7.0.1(react@19.2.5))(react@19.2.5)(zod@3.25.76)':
+    dependencies:
+      '@json-render/core': 0.16.0(zod@3.25.76)
+      ink: 7.0.1(react@19.2.5)
+      marked: 17.0.6
+      react: 19.2.5
+    transitivePeerDependencies:
+      - zod
 
   '@jsonjoy.com/base64@1.1.2(tslib@2.8.1)':
     dependencies:
@@ -2832,7 +3293,25 @@ snapshots:
       '@types/node': 22.19.3
     optional: true
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.8
+
   '@types/estree@1.0.8': {}
+
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@12.20.55': {}
 
@@ -2840,14 +3319,9 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@types/prop-types@15.7.15':
-    optional: true
+  '@types/unist@2.0.11': {}
 
-  '@types/react@18.3.27':
-    dependencies:
-      '@types/prop-types': 15.7.15
-      csstype: 3.2.3
-    optional: true
+  '@types/unist@3.0.3': {}
 
   '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@22.19.3)(jsdom@24.1.3))':
     dependencies:
@@ -2907,10 +3381,20 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 1.2.0
 
+  acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
+  acorn@8.16.0: {}
+
   agent-base@7.1.4:
     optional: true
 
   ansi-colors@4.1.3: {}
+
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
 
   ansi-regex@5.0.1: {}
 
@@ -2934,6 +3418,10 @@ snapshots:
 
   asynckit@0.4.0:
     optional: true
+
+  auto-bind@5.0.1: {}
+
+  bail@2.0.2: {}
 
   balanced-match@1.0.2: {}
 
@@ -2990,6 +3478,8 @@ snapshots:
       function-bind: 1.1.2
     optional: true
 
+  ccount@2.0.1: {}
+
   chai@5.3.3:
     dependencies:
       assertion-error: 2.0.1
@@ -3000,6 +3490,14 @@ snapshots:
 
   chalk@5.6.2: {}
 
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
+
   chardet@2.1.1: {}
 
   check-error@2.1.1: {}
@@ -3008,6 +3506,16 @@ snapshots:
     optional: true
 
   ci-info@3.9.0: {}
+
+  citty@0.1.6:
+    dependencies:
+      consola: 3.4.2
+
+  cli-boxes@4.0.1: {}
+
+  cli-cursor@4.0.0:
+    dependencies:
+      restore-cursor: 4.0.0
 
   cli-cursor@5.0.0:
     dependencies:
@@ -3021,7 +3529,16 @@ snapshots:
     optionalDependencies:
       '@colors/colors': 1.5.0
 
+  cli-truncate@6.0.0:
+    dependencies:
+      slice-ansi: 9.0.0
+      string-width: 8.2.1
+
   cli-width@4.1.0: {}
+
+  code-excerpt@4.0.0:
+    dependencies:
+      convert-to-spaces: 2.0.1
 
   color-convert@2.0.1:
     dependencies:
@@ -3036,6 +3553,10 @@ snapshots:
 
   commander@12.1.0: {}
 
+  consola@3.4.2: {}
+
+  convert-to-spaces@2.0.1: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -3046,9 +3567,6 @@ snapshots:
     dependencies:
       '@asamuzakjp/css-color': 3.2.0
       rrweb-cssom: 0.8.0
-    optional: true
-
-  csstype@3.2.3:
     optional: true
 
   data-urls@5.0.0:
@@ -3063,6 +3581,10 @@ snapshots:
 
   decimal.js@10.6.0:
     optional: true
+
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
 
   decompress-response@6.0.0:
     dependencies:
@@ -3086,22 +3608,27 @@ snapshots:
   delayed-stream@1.0.0:
     optional: true
 
+  dequal@2.0.3: {}
+
   detect-indent@6.1.0: {}
 
   detect-libc@2.1.2:
     optional: true
 
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
+
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
 
-  drizzle-orm@0.38.4(@cloudflare/workers-types@4.20260103.0)(@types/better-sqlite3@7.6.13)(@types/react@18.3.27)(better-sqlite3@11.10.0)(react@18.3.1):
+  drizzle-orm@0.38.4(@cloudflare/workers-types@4.20260103.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(react@19.2.5):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260103.0
       '@types/better-sqlite3': 7.6.13
-      '@types/react': 18.3.27
       better-sqlite3: 11.10.0
-      react: 18.3.1
+      react: 19.2.5
 
   dunder-proto@1.0.1:
     dependencies:
@@ -3131,6 +3658,8 @@ snapshots:
   entities@6.0.1:
     optional: true
 
+  environment@1.1.0: {}
+
   es-define-property@1.0.1:
     optional: true
 
@@ -3151,6 +3680,8 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.2
     optional: true
+
+  es-toolkit@1.46.1: {}
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -3178,7 +3709,18 @@ snapshots:
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
 
+  escape-string-regexp@2.0.0: {}
+
+  escape-string-regexp@5.0.0: {}
+
   esprima@4.0.1: {}
+
+  estree-util-is-identifier-name@3.0.0: {}
+
+  estree-util-visit@2.0.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/unist': 3.0.3
 
   estree-walker@3.0.3:
     dependencies:
@@ -3190,6 +3732,8 @@ snapshots:
     optional: true
 
   expect-type@1.3.0: {}
+
+  extend@3.0.2: {}
 
   extendable-error@0.1.7: {}
 
@@ -3206,6 +3750,10 @@ snapshots:
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
+
+  fault@2.0.1:
+    dependencies:
+      format: 0.2.2
 
   file-uri-to-path@1.0.0:
     optional: true
@@ -3233,6 +3781,8 @@ snapshots:
       mime-types: 2.1.35
     optional: true
 
+  format@0.2.2: {}
+
   fs-constants@1.0.0:
     optional: true
 
@@ -3255,6 +3805,8 @@ snapshots:
     optional: true
 
   get-east-asian-width@1.4.0: {}
+
+  get-east-asian-width@1.5.0: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -3382,11 +3934,54 @@ snapshots:
 
   ignore@5.3.2: {}
 
+  indent-string@5.0.0: {}
+
   inherits@2.0.4:
     optional: true
 
   ini@1.3.8:
     optional: true
+
+  ink@7.0.1(react@19.2.5):
+    dependencies:
+      '@alcalzone/ansi-tokenize': 0.3.0
+      ansi-escapes: 7.3.0
+      ansi-styles: 6.2.3
+      auto-bind: 5.0.1
+      chalk: 5.6.2
+      cli-boxes: 4.0.1
+      cli-cursor: 4.0.0
+      cli-truncate: 6.0.0
+      code-excerpt: 4.0.0
+      es-toolkit: 1.46.1
+      indent-string: 5.0.0
+      is-in-ci: 2.0.0
+      patch-console: 2.0.0
+      react: 19.2.5
+      react-reconciler: 0.33.0(react@19.2.5)
+      scheduler: 0.27.0
+      signal-exit: 3.0.7
+      slice-ansi: 9.0.0
+      stack-utils: 2.0.6
+      string-width: 8.2.1
+      terminal-size: 4.0.1
+      type-fest: 5.6.0
+      widest-line: 6.0.0
+      wrap-ansi: 10.0.0
+      ws: 8.20.0
+      yoga-layout: 3.2.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+
+  is-decimal@2.0.1: {}
 
   is-docker@3.0.0: {}
 
@@ -3394,9 +3989,17 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.5.0
+
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-hexadecimal@2.0.1: {}
+
+  is-in-ci@2.0.0: {}
 
   is-in-ssh@1.0.0: {}
 
@@ -3407,6 +4010,8 @@ snapshots:
   is-interactive@2.0.0: {}
 
   is-number@7.0.0: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1:
     optional: true
@@ -3458,9 +4063,6 @@ snapshots:
     dependencies:
       '@isaacs/cliui': 8.0.2
 
-  js-tokens@4.0.0:
-    optional: true
-
   js-yaml@3.14.2:
     dependencies:
       argparse: 1.0.10
@@ -3491,7 +4093,7 @@ snapshots:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
-      ws: 8.18.0
+      ws: 8.20.0
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -3519,10 +4121,7 @@ snapshots:
       chalk: 5.6.2
       is-unicode-supported: 1.3.0
 
-  loose-envify@1.4.0:
-    dependencies:
-      js-tokens: 4.0.0
-    optional: true
+  longest-streak@3.1.0: {}
 
   loupe@3.2.1: {}
 
@@ -3544,8 +4143,110 @@ snapshots:
     dependencies:
       semver: 7.7.3
 
+  marked@17.0.6: {}
+
   math-intrinsics@1.1.0:
     optional: true
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-frontmatter@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      escape-string-regexp: 5.0.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-extension-frontmatter: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx@3.0.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
+  mdast@3.0.0: {}
 
   memfs@4.51.1:
     dependencies:
@@ -3557,6 +4258,219 @@ snapshots:
       tslib: 2.8.1
 
   merge2@1.4.1: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-frontmatter@2.0.0:
+    dependencies:
+      fault: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdx-expression@3.0.1:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      micromark-factory-mdx-expression: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdx-jsx@3.0.2:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      micromark-factory-mdx-expression: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      vfile-message: 4.0.3
+
+  micromark-extension-mdx-md@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdxjs-esm@3.0.0:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-position-from-estree: 2.0.0
+      vfile-message: 4.0.3
+
+  micromark-extension-mdxjs@3.0.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      micromark-extension-mdx-expression: 3.0.1
+      micromark-extension-mdx-jsx: 3.0.2
+      micromark-extension-mdx-md: 2.0.0
+      micromark-extension-mdxjs-esm: 3.0.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-mdx-expression@2.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-position-from-estree: 2.0.0
+      vfile-message: 4.0.3
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-events-to-acorn@2.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      estree-util-visit: 2.0.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      vfile-message: 4.0.3
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   micromatch@4.0.8:
     dependencies:
@@ -3570,6 +4484,8 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
     optional: true
+
+  mimic-fn@2.1.0: {}
 
   mimic-function@5.0.1: {}
 
@@ -3615,6 +4531,10 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
     optional: true
+
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
 
   onetime@7.0.0:
     dependencies:
@@ -3665,10 +4585,22 @@ snapshots:
     dependencies:
       quansync: 0.2.11
 
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
   parse5@7.3.0:
     dependencies:
       entities: 6.0.1
     optional: true
+
+  patch-console@2.0.0: {}
 
   path-exists@4.0.0: {}
 
@@ -3753,10 +4685,12 @@ snapshots:
       strip-json-comments: 2.0.1
     optional: true
 
-  react@18.3.1:
+  react-reconciler@0.33.0(react@19.2.5):
     dependencies:
-      loose-envify: 1.4.0
-    optional: true
+      react: 19.2.5
+      scheduler: 0.27.0
+
+  react@19.2.5: {}
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -3772,10 +4706,46 @@ snapshots:
       util-deprecate: 1.0.2
     optional: true
 
+  remark-frontmatter@5.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-frontmatter: 2.0.1
+      micromark-extension-frontmatter: 2.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-mdx@3.1.1:
+    dependencies:
+      mdast-util-mdx: 3.0.0
+      micromark-extension-mdxjs: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
+
   requires-port@1.0.0:
     optional: true
 
   resolve-from@5.0.0: {}
+
+  restore-cursor@4.0.0:
+    dependencies:
+      onetime: 5.1.2
+      signal-exit: 3.0.7
 
   restore-cursor@5.1.0:
     dependencies:
@@ -3834,6 +4804,8 @@ snapshots:
       xmlchars: 2.2.0
     optional: true
 
+  scheduler@0.27.0: {}
+
   semver@7.7.3: {}
 
   shebang-command@2.0.0:
@@ -3843,6 +4815,8 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   siginfo@2.0.0: {}
+
+  signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
 
@@ -3866,6 +4840,11 @@ snapshots:
 
   slash@3.0.0: {}
 
+  slice-ansi@9.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
   source-map-js@1.2.1: {}
 
   spawndamnit@3.0.1:
@@ -3874,6 +4853,10 @@ snapshots:
       signal-exit: 4.1.0
 
   sprintf-js@1.0.3: {}
+
+  stack-utils@2.0.6:
+    dependencies:
+      escape-string-regexp: 2.0.0
 
   stackback@0.0.2: {}
 
@@ -3899,10 +4882,20 @@ snapshots:
       get-east-asian-width: 1.4.0
       strip-ansi: 7.1.2
 
+  string-width@8.2.1:
+    dependencies:
+      get-east-asian-width: 1.5.0
+      strip-ansi: 7.1.2
+
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
     optional: true
+
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
 
   strip-ansi@6.0.1:
     dependencies:
@@ -3924,6 +4917,8 @@ snapshots:
   symbol-tree@3.2.4:
     optional: true
 
+  tagged-tag@1.0.0: {}
+
   tar-fs@2.1.4:
     dependencies:
       chownr: 1.1.4
@@ -3942,6 +4937,8 @@ snapshots:
     optional: true
 
   term-size@2.2.1: {}
+
+  terminal-size@4.0.1: {}
 
   test-exclude@7.0.1:
     dependencies:
@@ -3984,6 +4981,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  trough@2.2.0: {}
+
   ts-algebra@2.0.0: {}
 
   tslib@2.8.1: {}
@@ -4020,9 +5019,46 @@ snapshots:
       turbo-windows-64: 2.7.2
       turbo-windows-arm64: 2.7.2
 
+  type-fest@5.6.0:
+    dependencies:
+      tagged-tag: 1.0.0
+
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
+
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position-from-estree@2.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   universal-user-agent@7.0.3: {}
 
@@ -4039,6 +5075,16 @@ snapshots:
 
   util-deprecate@1.0.2:
     optional: true
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite-node@2.1.9(@types/node@22.19.3):
     dependencies:
@@ -4134,6 +5180,16 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  widest-line@6.0.0:
+    dependencies:
+      string-width: 8.2.1
+
+  wrap-ansi@10.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 8.2.1
+      strip-ansi: 7.1.2
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -4155,8 +5211,7 @@ snapshots:
   wrappy@1.0.2:
     optional: true
 
-  ws@8.18.0:
-    optional: true
+  ws@8.20.0: {}
 
   wsl-utils@0.3.1:
     dependencies:
@@ -4171,6 +5226,8 @@ snapshots:
 
   yaml@2.8.2: {}
 
+  yoga-layout@3.2.1: {}
+
   zod-validation-error@5.0.0(zod@3.25.76):
     dependencies:
       zod: 3.25.76
@@ -4178,3 +5235,5 @@ snapshots:
   zod@3.24.1: {}
 
   zod@3.25.76: {}
+
+  zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary

First-class support for [Google's DESIGN.md spec](https://github.com/google-labs-code/design.md) in the `buoy` CLI. This is **Phase A** of a multi-phase rollout — Phase B (cloud + dashboard editor) lands separately in `buoy-cloud`.

- Adds `buoy designmd {lint, diff, export, init}` subcommands. `lint`/`diff`/`export` thin-wrap `@google/design.md/linter`; `init` is Buoy-original (token discovery → DESIGN.md skeleton).
- Adds a Buoy-side adapter at `@buoy-design/core` so all DESIGN.md handling flows through one bump point.
- Scanner now prefers `DESIGN.md` tokens over auto-discovered `tokens.css` for `colors`/`spacing`/`rounded` when DESIGN.md exists at the project root. Other token sources are unaffected.

## Architecture

| Layer | What changed |
|---|---|
| `@buoy-design/core` | New `designmd/` module: `parseDesignMd`, `designMdToTokens`, Buoy-facing types. Pinned `@google/design.md@0.1.1`. |
| `@buoy-design/scanners` | Pinned `@google/design.md@0.1.1` for Phase B (no scanner code changes yet). |
| `@buoy-design/cli` | New `designmd` command group. Orchestrator gains `applyDesignMdPrecedence`. `findTokenFiles` now matches `DESIGN.md`. |

## Findings discovered during implementation

These are documented in code comments where relevant, but worth surfacing for reviewers:

1. **README export paths are wrong.** Both runtime AND types live at `@google/design.md/linter`. Importing the root specifier `@google/design.md` executes the citty CLI on import. Adapter and tests use `/linter` exclusively.
2. **Upstream returns `Map`s, not `Record`s; `infos` not `info`; lowercases hex.** Adapter normalizes at the boundary so consumers see the documented Buoy types.
3. **`@google/design.md@0.1.1` does NOT enforce token references** (`{colors.does-not-exist}` passes lint). Test fixtures use invalid hex (`not-a-hex`) which DOES trigger errors. Comments added to the relevant tests.
4. **No `radius`/`rounded` category in `DesignToken`.** DESIGN.md `rounded.*` projects to `category: "other"` with `value: { type: "raw" }`. Lossy but explicit.

## Out of scope (tracked separately)

- **Cloud + dashboard editor** — Phase B, separate PR in `ahoybuoy/buoy-cloud`.
- **Component reconciliation, diff regression gate, user-OAuth** — `ahoybuoy/buoy-cloud#10`.

## Test plan

- [x] `pnpm test` — 2670 passed, 1 skipped (was 2646 baseline → +24 new tests)
- [x] `pnpm build` — 3/3 packages compile cleanly
- [x] Manual smoke: `buoy designmd init`, `lint`, `diff`, `export --format tailwind|dtcg` all exit 0 against generated fixtures
- [x] Integration test against real `test-fixture/` discovers tokens and emits parseable DESIGN.md
- [x] Scanner integration test confirms DESIGN.md tokens replace CSS-discovered ones for owned categories, additive contract preserved when DESIGN.md is absent
- [ ] Reviewer to verify the canonical CLI install (`pnpm pack apps/cli && npm i -g <tarball>`) exposes `buoy designmd` correctly

## Commits (11)

```
58c291c fix(designmd): address deferred review findings (type drift, dead re-export, test docs)
760ea6d feat: scanner prefers DESIGN.md tokens over auto-discovered CSS
7b4c083 feat(cli): wire 'designmd init' to real token discovery
f72e68c feat(cli): register 'designmd' command group in CLI router
c98cbd9 feat(cli): add 'buoy designmd init' generator (skeleton)
d10482b feat(cli): add 'buoy designmd export' (tailwind, dtcg)
58bbe67 feat(cli): add 'buoy designmd diff' command
0ad2a10 feat(cli): add 'buoy designmd lint' command
f4efc94 fix(core): validate severity strings and cover parse-error path
fda40cd feat(core): add DESIGN.md adapter wrapping @google/design.md/linter
2abfc27 chore: add @google/design.md@0.1.1 runtime dependency
```

26 files changed, +2335 / -44.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added DESIGN.md format support for defining design tokens in your project.
  * New CLI subcommands for DESIGN.md: `lint`, `diff`, `export`, and `init` to manage design token files.
  * DESIGN.md tokens now take precedence during token scanning and detection.
  * Export tokens in Tailwind or DTCG format for use in your design system.

* **Tests**
  * Added comprehensive test coverage for DESIGN.md parsing and CLI operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ahoybuoy/buoy/pull/15)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->